### PR TITLE
feat: implement changelog system for provider data

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # <-- gives this job push rights
+    env:
+      BASE_SHA: ${{ github.event_name == 'push' && github.event.before || github.event.pull_request.base.sha }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -57,10 +59,22 @@ jobs:
             ${{ runner.os }}-node-
       - run: npm ci
       - run: npm run build # rebuild against up-to-date main
-      - name: Commit and push dist/
+      - name: Detect changed provider files
+        id: files
+        run: |
+          git diff --name-only $BASE_SHA $GITHUB_SHA -- providers/**/data.json \
+            | tr '\n' ' ' | sed 's/ $//' | tee files.txt
+          echo "FILES=$(cat files.txt)" >> $GITHUB_OUTPUT
+      - name: Update changelogs
+        if: steps.files.outputs.FILES != ''
+        run: |
+          for f in ${{ steps.files.outputs.FILES }}; do
+            npm run changelog "$f"
+          done
+      - name: Commit and push changes
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add dist/
-          git commit -m "chore: update aggregate data" --no-verify || echo "No changes to commit"
+          git add dist/ providers/*/changelog.json providers/*/CHANGELOG.md
+          git commit -m "chore: update build artifacts and changelogs" --no-verify || echo "No changes to commit"
           git push

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "validate": "node scripts/validate.js",
     "build": "npm run validate && node scripts/build-aggregate.js",
+    "changelog": "node scripts/update-changelog.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",

--- a/providers/aave/CHANGELOG.md
+++ b/providers/aave/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Aave
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/aave/changelog.json
+++ b/providers/aave/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "aave",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/arch/CHANGELOG.md
+++ b/providers/arch/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Arch
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/arch/changelog.json
+++ b/providers/arch/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "arch",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/binance/CHANGELOG.md
+++ b/providers/binance/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Binance
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/binance/changelog.json
+++ b/providers/binance/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "binance",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/coinbase/CHANGELOG.md
+++ b/providers/coinbase/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Coinbase
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/coinbase/changelog.json
+++ b/providers/coinbase/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "coinbase",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/coinrabbit/CHANGELOG.md
+++ b/providers/coinrabbit/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Coinrabbit
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/coinrabbit/changelog.json
+++ b/providers/coinrabbit/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "coinrabbit",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/debifi/CHANGELOG.md
+++ b/providers/debifi/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Debifi
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/debifi/changelog.json
+++ b/providers/debifi/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "debifi",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/firefish/CHANGELOG.md
+++ b/providers/firefish/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Firefish
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/firefish/changelog.json
+++ b/providers/firefish/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "firefish",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/hodlhodl/CHANGELOG.md
+++ b/providers/hodlhodl/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Hodlhodl
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/hodlhodl/changelog.json
+++ b/providers/hodlhodl/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "hodlhodl",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/lava/CHANGELOG.md
+++ b/providers/lava/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Lava
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/lava/changelog.json
+++ b/providers/lava/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "lava",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/ledn/CHANGELOG.md
+++ b/providers/ledn/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Ledn
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/ledn/changelog.json
+++ b/providers/ledn/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "ledn",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/lendasat/CHANGELOG.md
+++ b/providers/lendasat/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Lendasat
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/lendasat/changelog.json
+++ b/providers/lendasat/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "lendasat",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/libre/CHANGELOG.md
+++ b/providers/libre/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Libre
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/libre/changelog.json
+++ b/providers/libre/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "libre",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/nexo/CHANGELOG.md
+++ b/providers/nexo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Nexo
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/nexo/changelog.json
+++ b/providers/nexo/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "nexo",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/salt/CHANGELOG.md
+++ b/providers/salt/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Salt
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/salt/changelog.json
+++ b/providers/salt/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "salt",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/strike/CHANGELOG.md
+++ b/providers/strike/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Strike
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/strike/changelog.json
+++ b/providers/strike/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "strike",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/providers/unchained/CHANGELOG.md
+++ b/providers/unchained/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog - Unchained
+
+## 2025-08-07
+**Action:** bootstrap  
+*Tracking starts from this date; edits made before 2025-08-07 are not included.*
+
+---

--- a/providers/unchained/changelog.json
+++ b/providers/unchained/changelog.json
@@ -1,0 +1,12 @@
+{
+  "provider": "unchained",
+  "logs": [
+    {
+      "action": "bootstrap",
+      "changedAt": "2025-08-07T00:00:00Z",
+      "changedBy": "migration-script",
+      "changes": {},
+      "note": "Changelog system initialized. Historical changes before this date are not tracked."
+    }
+  ]
+}

--- a/scripts/update-changelog.js
+++ b/scripts/update-changelog.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * update-changelog.js
+ *
+ * Usage:  node scripts/update-changelog.js providers/libre/data.json
+ *
+ * Must be run from the repo root in a Git working tree that already
+ * contains the *new* version of the provider file (i.e. after checkout).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+/* ---------- helpers ------------------------------------------------------ */
+
+const readJSON = p => JSON.parse(fs.readFileSync(p, 'utf8'));
+
+const baseSha = process.env.BASE_SHA || 'HEAD^';
+
+const gitShowJSON = (file, sha = baseSha) => {
+  try {
+    const out = execSync(`git show ${sha}:${file}`, { encoding: 'utf8' });
+    return JSON.parse(out);
+  } catch {
+    return null; // file did not exist at base SHA
+  }
+};
+
+const getCommitInfo = () => {
+  try {
+    const hash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+    const message = execSync('git log -1 --pretty=format:%s', {
+      encoding: 'utf8',
+    }).trim();
+    return { hash: hash.substring(0, 8), message };
+  } catch {
+    return { hash: 'unknown', message: 'unknown' };
+  }
+};
+
+const deepDiff = (a, b, prefix = '') => {
+  const out = {};
+  const keys = new Set([
+    ...(a ? Object.keys(a) : []),
+    ...(b ? Object.keys(b) : []),
+  ]);
+
+  for (const k of keys) {
+    const pa = a ? a[k] : undefined;
+    const pb = b ? b[k] : undefined;
+    const keyPath = prefix ? `${prefix}.${k}` : k;
+
+    if (JSON.stringify(pa) === JSON.stringify(pb)) continue;
+
+    if (
+      pa &&
+      pb &&
+      typeof pa === 'object' &&
+      typeof pb === 'object' &&
+      !Array.isArray(pa) &&
+      !Array.isArray(pb)
+    ) {
+      Object.assign(out, deepDiff(pa, pb, keyPath));
+    } else {
+      out[keyPath] = {
+        from: pa === undefined ? null : pa,
+        to: pb === undefined ? null : pb,
+      };
+    }
+  }
+  return out;
+};
+
+const toMd = val => {
+  if (val === null || val === undefined) return '`null`';
+  if (typeof val === 'object') {
+    return `\n\`\`\`json\n${JSON.stringify(val, null, 2)}\n\`\`\`\n`;
+  }
+  return `\`${String(val)}\``;
+};
+
+/* ---------- main --------------------------------------------------------- */
+
+const providerFile = process.argv[2];
+if (!providerFile || !fs.existsSync(providerFile)) {
+  console.error(
+    '❌  Must pass path to provider JSON, e.g. providers/libre/data.json'
+  );
+  process.exit(1);
+}
+
+const next = readJSON(providerFile);
+const prev = gitShowJSON(providerFile); // Uses BASE_SHA automatically
+const slug = next.slug;
+const nowISO = new Date().toISOString();
+const commitInfo = getCommitInfo();
+
+const diff = deepDiff(prev, next);
+if (Object.keys(diff).length === 0) {
+  console.log(`ℹ️  No user-visible changes for ${slug}. Skipping changelog.`);
+  process.exit(0);
+}
+
+/* --- load / initialise changelog ---------------------------------------- */
+
+const dir = path.dirname(providerFile);
+const jsonPath = path.join(dir, 'changelog.json');
+const mdPath = path.join(dir, 'CHANGELOG.md');
+
+let changelog = { provider: slug, logs: [] };
+if (fs.existsSync(jsonPath)) changelog = readJSON(jsonPath);
+
+/* --- append entry -------------------------------------------------------- */
+
+changelog.logs.push({
+  action: prev ? 'update' : 'publish',
+  changedAt: nowISO,
+  changedBy: process.env.GITHUB_ACTOR || 'ci-bot',
+  commit: commitInfo.hash,
+  commitMessage: commitInfo.message,
+  changes: diff,
+});
+
+/* --- write JSON ---------------------------------------------------------- */
+
+fs.writeFileSync(jsonPath, `${JSON.stringify(changelog, null, 2)}\n`);
+console.log(`✅  Updated ${jsonPath}`);
+
+/* --- write / update Markdown -------------------------------------------- */
+
+const mdLines = [];
+
+if (fs.existsSync(mdPath)) {
+  mdLines.push(fs.readFileSync(mdPath, 'utf8').trimEnd());
+} else {
+  mdLines.push(`# Changelog - ${next.provider_name || slug}\n`);
+}
+
+mdLines.push(
+  `## ${nowISO.slice(0, 10)}`,
+  `**Action:** ${prev ? 'update' : 'publish'}`,
+  `**By:** ${process.env.GITHUB_ACTOR || 'ci-bot'}`,
+  `**Commit:** [${commitInfo.hash}](https://github.com/your-repo/commit/${commitInfo.hash})`,
+  `**Message:** ${commitInfo.message}\n`,
+  '### Changed'
+);
+
+for (const [k, v] of Object.entries(diff)) {
+  mdLines.push(`- **${k}:** ${toMd(v.from)} → ${toMd(v.to)}`);
+}
+
+mdLines.push('\n---\n');
+fs.writeFileSync(mdPath, mdLines.join('\n'));
+console.log(`✅  Updated ${mdPath}`);


### PR DESCRIPTION
…ultiple providers

<!--
PR TITLE GUIDELINE
------------------
If you’re adding or updating a provider file, start the title with “provider/<slug>: ”,
e.g.  provider/debifi: add rehypothecation evidence
-->

## ✨ What’s new?

- Add script to generate changelog whenever provider data changes
- Update build workflow to trigger changelog generation

---

## 📄 Context / Motivation

- Track all provider data changes

---

## 🗂️ Type of change (pick one)

- [ ] 🆕 **New provider** – adding `providers/<slug>/data.json`
- [ ] 📝 **Update provider** – editing an existing provider file
- [ ] 📚 **Docs / README / meta**
- [ ] 🐛 **Fix** – bug fix, lint tweak, misc
- [x] 🚀 **Other** (explain below)

- Implement changelog system

---

## ✅ Checklist

> Please tick the boxes that apply.

- [x] I ran **`npm run validate`** locally and it passed.
- [x] I ran **`npm run build`** locally (**dist/** _not_ committed).
- [ ] Provider data follows `provider.schema.json` (all required fields present).
- [ ] Evidence objects include **`source_url`** and **`captured_at`**.
- [ ] CI passes (you’ll see the green checkmarks below).

---

## 🔗 Evidence / Screenshots (optional)



---

## 📢 Anything else?


